### PR TITLE
More formats

### DIFF
--- a/src/twitter-mention.coffee
+++ b/src/twitter-mention.coffee
@@ -12,6 +12,7 @@
 #   HUBOT_TWITTER_ACCESS_TOKEN_SECRET
 #   HUBOT_TWITTER_MENTION_QUERY
 #   HUBOT_TWITTER_MENTION_ROOM
+#   HUBOT_TWITTER_MESSAGE_FORMAT ('plaintext', 'markdown', 'slack')
 #
 # Commands:
 #   none

--- a/src/twitter-mention.coffee
+++ b/src/twitter-mention.coffee
@@ -23,7 +23,7 @@
 TWIT = require "twit"
 MENTION_ROOM = process.env.HUBOT_TWITTER_MENTION_ROOM || "#general"
 MAX_TWEETS = 50
-MESSAGE_FORMAT = process.env.HUBOT_TWITTER_MESSAGE_FORMAT || "markdown"
+MESSAGE_FORMAT = process.env.HUBOT_TWITTER_MESSAGE_FORMAT || "plaintext"
 
 config =
   consumer_key: process.env.HUBOT_TWITTER_CONSUMER_KEY

--- a/src/twitter-mention.coffee
+++ b/src/twitter-mention.coffee
@@ -52,10 +52,11 @@ module.exports = (robot) ->
       if data.statuses? and data.statuses.length > 0
         robot.brain.data.last_tweet = data.statuses[0].id_str
         for tweet in data.statuses.reverse()
-          message = "Tweet Alert: http://twitter.com/#{tweet.user.screen_name}/status/#{tweet.id_str}"
           if robot.adapterName != "slack"
+            message = "> #{tweet.text}\n\nfrom [#{tweet.user.screen_name}](https://twitter.com/#{tweet.user.screen_name}) (#{tweet.user.name}) @ https://twitter.com/#{tweet.user.screen_name}/status/#{tweet.id_str}"
             robot.messageRoom MENTION_ROOM, message
           else
+            message = "Tweet Alert: http://twitter.com/#{tweet.user.screen_name}/status/#{tweet.id_str}"
             robot.logger.info tweet
             robot.emit 'slack-attachment',
               channel: "#{MENTION_ROOM}"

--- a/src/twitter-mention.coffee
+++ b/src/twitter-mention.coffee
@@ -23,6 +23,7 @@
 TWIT = require "twit"
 MENTION_ROOM = process.env.HUBOT_TWITTER_MENTION_ROOM || "#general"
 MAX_TWEETS = 50
+MESSAGE_FORMAT = process.env.HUBOT_TWITTER_MESSAGE_FORMAT || "markdown"
 
 config =
   consumer_key: process.env.HUBOT_TWITTER_CONSUMER_KEY
@@ -35,6 +36,45 @@ getTwit = ->
     twit = new TWIT config
 
 module.exports = (robot) ->
+  if robot.adapterName == "slack"
+    MESSAGE_FORMAT="slack"
+
+  shareTweet = (tweet) ->
+    tweet_url = "https://twitter.com/#{tweet.user.screen_name}/status/#{tweet.id_str}"
+    switch MESSAGE_FORMAT
+      when "slack"
+        message = "Tweet Alert: #{tweet_url}"
+        robot.emit 'slack-attachment',
+          channel: "#{MENTION_ROOM}"
+          content:
+            color: "#55acee"
+            fallback: "#{message}"
+            text: "#{tweet.text}"
+            author_name: "#{tweet.user.name} (@#{tweet.user.screen_name})"
+            author_link: "http://twitter.com/#{tweet.user.screen_name}"
+            title: "#{tweet_url}"
+            title_link: "#{tweet_url}"
+            thumb_url: "#{tweet.user.profile_image_url}"
+            fields: [
+                {
+                    "title": "Stats",
+                    "value": "Retweets: #{tweet.retweet_count} | Like: #{tweet.favorite_count} | Followers: #{tweet.user.followers_count} | Friends: #{tweet.user.friends_count}",
+                    "short": false
+                }
+            ]
+      when "markdown"
+        message = """
+          #{tweet.text}
+          *[@#{tweet.user.screen_name}](https://twitter.com/#{tweet.user.screen_name}) (#{tweet.user.name}) on Twitter @ [#{tweet.created_at}](#{tweet_url})*
+        """
+        robot.messageRoom MENTION_ROOM, message
+      when "plaintext"
+        message = """
+          #{tweet.text}
+          - #{tweet_url}
+        """
+        robot.messageRoom MENTION_ROOM, message
+
   robot.brain.on 'loaded', =>
     robot.brain.data.last_tweet ||= '1'
     doAutomaticSearch(robot)
@@ -52,30 +92,7 @@ module.exports = (robot) ->
       if data.statuses? and data.statuses.length > 0
         robot.brain.data.last_tweet = data.statuses[0].id_str
         for tweet in data.statuses.reverse()
-          if robot.adapterName != "slack"
-            message = "> #{tweet.text}\n\nfrom [#{tweet.user.screen_name}](https://twitter.com/#{tweet.user.screen_name}) (#{tweet.user.name}) @ https://twitter.com/#{tweet.user.screen_name}/status/#{tweet.id_str}"
-            robot.messageRoom MENTION_ROOM, message
-          else
-            message = "Tweet Alert: http://twitter.com/#{tweet.user.screen_name}/status/#{tweet.id_str}"
-            robot.logger.info tweet
-            robot.emit 'slack-attachment',
-              channel: "#{MENTION_ROOM}"
-              content:
-                color: "#55acee"
-                fallback: "#{message}"
-                text: "#{tweet.text}"
-                author_name: "#{tweet.user.name} (@#{tweet.user.screen_name})"
-                author_link: "http://twitter.com/#{tweet.user.screen_name}"
-                title: "http://twitter.com/#{tweet.user.screen_name}/status/#{tweet.id_str}"
-                title_link: "http://twitter.com/#{tweet.user.screen_name}/status/#{tweet.id_str}"
-                thumb_url: "#{tweet.user.profile_image_url}"
-                fields: [
-                    {
-                        "title": "Stats",
-                        "value": "Retweets: #{tweet.retweet_count} | Like: #{tweet.favorite_count} | Followers: #{tweet.user.followers_count} | Friends: #{tweet.user.friends_count}",
-                        "short": false
-                    }
-                ]
+          shareTweet tweet
 
     setTimeout (->
       doAutomaticSearch(robot)


### PR DESCRIPTION
Handle some different formats nicely.

Configure via HUBOT_TWITTER_MESSAGE_FORMAT which can be `slack` (autodetected via checking adapter anyway), `markdown` (Mattermost and friends, or Slack if you wish), `plaintext` (let's not be mean to IRC bots).