### PR TITLE
Run Twitter search task once only

### DIFF
--- a/src/twitter-mention.coffee
+++ b/src/twitter-mention.coffee
@@ -77,8 +77,9 @@ module.exports = (robot) ->
         """
         robot.messageRoom MENTION_ROOM, message
 
-  robot.brain.on 'loaded', =>
+  robot.brain.once 'loaded', =>
     robot.brain.data.last_tweet ||= '1'
+    robot.logger.info 'twitter-mention poller starting at ' + robot.brain.data.last_tweet
     doAutomaticSearch(robot)
 
   doAutomaticSearch = (robot) ->


### PR DESCRIPTION
Run Twitter search task once only, not every time the robot.brain 'loaded' event hook fires.

Refs #4, xurizaemon/bolts#15